### PR TITLE
[DataInfra][xplat][ldText][1/n]Create the implementation of ldText

### DIFF
--- a/LionDiningDataModels/LionDiningTextImplementation.swift
+++ b/LionDiningDataModels/LionDiningTextImplementation.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+// Define a class to hold the list of pairs and methods
+class PairList {
+    // Define the type for the pair
+    typealias Pair = (String, String)
+    
+    // Initialize the list of pairs
+    private var pairs: [Pair]
+    
+    init(pairs: [Pair] = []) {
+        self.pairs = pairs
+    }
+    
+    // Method to get the first string as it is
+    func ldGetText(_ input: String) -> String {
+        return input
+    }
+    
+    // Method to get the corresponding second string
+    func ldGetTextDescription(_ input: String) -> String? {
+        for pair in pairs {
+            if pair.0 == input {
+                return pair.1
+            }
+        }
+        return nil
+    }
+    
+    // Method to add a new pair
+    func addPair(first: String, second: String) {
+        pairs.append((first, second))
+    }
+}


### PR DESCRIPTION
This CR:

adds the implementation of ldText, which is the internal version of strings used in texts for public display. This ldText should be used in all times, in replacement of traditional, built-in string in Swift. 

creates method to call ldGetText() to get the string (used the same as traditional vanilla string). For example, ldGetText("ABC") returns "ABC". 

creates method to call ldGetTextDescription(), which can return the description of the text. For example, ldGetTextDescription("Time for lunch!") can return "This is an alert that remind user it is lunchtime". The purpose of this is to document the purpose and context of this text, paving the way for translations in the future. 

Test plan:

To be implemented. Currently, no code is calling this class, so it should not impact any existing features.

Privacy Review:

Since this class is for LD internal use, we should keep this confidential. We should not store any customer-sensitive data into this class, so that translators will not see confidential information.